### PR TITLE
Send event when cancelling google payment

### DIFF
--- a/android/src/main/java/com/rnlib/adyen/AdyenComponent.kt
+++ b/android/src/main/java/com/rnlib/adyen/AdyenComponent.kt
@@ -34,6 +34,7 @@ object AdyenComponent {
     private val TAG = LogUtil.getTag()
 
     const val DROP_IN_REQUEST_CODE = 529
+    const val GOOGLE_PAY_REQUEST_CODE = 530
 
     const val RESULT_KEY = "payment_result"
     const val ERROR_REASON_KEY = "error_reason"
@@ -88,7 +89,8 @@ object AdyenComponent {
         activity: Activity,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         adyenComponentConfiguration: AdyenComponentConfiguration,
-        resultHandlerIntent: Intent? = null
+        resultHandlerIntent: Intent? = null,
+        requestCode: Int = DROP_IN_REQUEST_CODE
     ) {
         Logger.d(TAG, "startPayment from Activity")
 
@@ -98,7 +100,7 @@ object AdyenComponent {
             adyenComponentConfiguration,
             resultHandlerIntent
         )
-        activity.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
+        activity.startActivityForResult(intent, requestCode)
     }
 
     /**

--- a/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
+++ b/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
@@ -389,7 +389,8 @@ class AdyenPaymentModule(private var reactContext : ReactApplicationContext) : R
         val googlePayConfig = googlePayConfigBuilder.build()
         val configBuilder : AdyenComponentConfiguration.Builder = createConfigurationBuilder(context)
         configBuilder.addGooglePayConfiguration(googlePayConfig)
-        AdyenComponent.startPayment(currentActivity!!, paymentMethodsApiResponse, configBuilder.build())
+        AdyenComponent.startPayment(currentActivity!!, paymentMethodsApiResponse, configBuilder.build(),
+            null, AdyenComponent.GOOGLE_PAY_REQUEST_CODE)
     }
  
     private fun showDropInComponent(componentData : JSONObject) {
@@ -564,9 +565,13 @@ class AdyenPaymentModule(private var reactContext : ReactApplicationContext) : R
     @Suppress("UNUSED_PARAMETER")
     private fun parseActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         Log.d(TAG, "parseActivityResult")
-        if (requestCode == DropIn.DROP_IN_REQUEST_CODE && resultCode == Activity.RESULT_CANCELED && data != null) {
-//            sendFailure("ERROR_CANCELLED","Transaction Cancelled")
-            Log.d(TAG, "DropIn CANCELED")
+        if (resultCode == Activity.RESULT_CANCELED) {
+            if (requestCode == AdyenComponent.DROP_IN_REQUEST_CODE && data != null) {
+                sendFailure("ERROR_CANCELLED", "Transaction Cancelled")
+                Log.d(TAG, "DropIn CANCELED")
+            } else if (requestCode == AdyenComponent.GOOGLE_PAY_REQUEST_CODE) {
+                sendFailure("GOOGLE_PAY_CANCELLED", "Google transaction canceled")
+            }
         }
     }
 


### PR DESCRIPTION
We need to track when native payments are canceled in spin-mobile, so for this we need to send a code in case user cancels the payment with google.