### PR TITLE
Handle payment result using onActivityResult instead of onNewIntent

### DIFF
--- a/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
+++ b/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
@@ -572,10 +572,17 @@ class AdyenPaymentModule(private var reactContext : ReactApplicationContext) : R
     }
 
     @Suppress("UNUSED_PARAMETER")
-    private fun parseActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    private fun parseActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         Log.d(TAG, "parseActivityResult")
+        if ((requestCode == AdyenComponent.GOOGLE_PAY_REQUEST_CODE ||
+                    requestCode == AdyenComponent.DROP_IN_REQUEST_CODE) &&
+            resultCode == Activity.RESULT_OK && intent != null) {
+            val response = JSONObject(intent.getStringExtra(AdyenComponent.RESULT_KEY))
+            sendResponse(response)
+        }
+
         if (resultCode == Activity.RESULT_CANCELED) {
-            if (requestCode == AdyenComponent.DROP_IN_REQUEST_CODE && data != null) {
+            if (requestCode == AdyenComponent.DROP_IN_REQUEST_CODE && intent != null) {
                 sendFailure("ERROR_CANCELLED", "Transaction Cancelled")
                 Log.d(TAG, "DropIn CANCELED")
             } else if (requestCode == AdyenComponent.GOOGLE_PAY_REQUEST_CODE) {

--- a/android/src/main/java/com/rnlib/adyen/ui/AdyenComponentActivity.kt
+++ b/android/src/main/java/com/rnlib/adyen/ui/AdyenComponentActivity.kt
@@ -1,5 +1,6 @@
 package com.rnlib.adyen.ui
 
+import android.app.Activity
 import android.content.*
 import android.content.res.Configuration
 import android.os.Bundle
@@ -439,10 +440,9 @@ class AdyenComponentActivity : AppCompatActivity(), DropInBottomSheetDialogFragm
     }
 
     private fun sendResult(content: String) {
-        adyenComponentViewModel.adyenComponentConfiguration.resultHandlerIntent
-            .putExtra(AdyenComponent.RESULT_KEY, content).let { intent ->
-                startActivity(intent)
-            }
+        val resultIntent = Intent()
+        resultIntent.putExtra(AdyenComponent.RESULT_KEY, content)
+        setResult(Activity.RESULT_OK, resultIntent)
         terminateSuccessfully()
     }
 
@@ -453,10 +453,9 @@ class AdyenComponentActivity : AppCompatActivity(), DropInBottomSheetDialogFragm
 
     private fun terminateWithError(reason: String) {
         Logger.d(TAG, "terminateWithError")
-        adyenComponentViewModel.adyenComponentConfiguration.resultHandlerIntent
-            .putExtra(AdyenComponent.ERROR_REASON_KEY, reason).let { intent ->
-                startActivity(intent)
-            }
+        val resultIntent = Intent()
+        resultIntent.putExtra(AdyenComponent.ERROR_REASON_KEY, reason)
+        setResult(Activity.RESULT_CANCELED, resultIntent)
         terminate()
     }
 


### PR DESCRIPTION
Guys, this is for this ticket:
https://spinbikes.atlassian.net/browse/PAYX-3166

The thing is how the library is working right now, it launches a failure when the native pay screen closes, this is because the intent when the payment is added is handled with onNewIntent() instead of onActivityResult which is how a result intent should be handled