### PR TITLE
Handle null Loading DialogFragment after adding card

### DIFF
--- a/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
+++ b/android/src/main/java/com/rnlib/adyen/AdyenPaymentModule.kt
@@ -599,8 +599,10 @@ class AdyenPaymentModule(private var reactContext : ReactApplicationContext) : R
                 loadingDialog.show(curr_fragment_mgr, LOADING_FRAGMENT_TAG)
             }
         } else {
-            val df : DialogFragment = curr_fragment_mgr.findFragmentByTag(LOADING_FRAGMENT_TAG) as DialogFragment
-            df.dismiss()
+            // DialogFragment can be null if this is called after getting an async response but
+            // user closed the screen
+            val df: DialogFragment? = curr_fragment_mgr.findFragmentByTag(LOADING_FRAGMENT_TAG) as DialogFragment?
+            df?.dismiss()
         }
     }
 


### PR DESCRIPTION
This error was causing the app to crash when wanted to hide a dialog fragment that was null because the activity was destroyed. This is the ticket
https://spinbikes.atlassian.net/browse/PAYX-3199