### PR TITLE
Use 'kotlin-parcelize' instead of 'kotlin-android-extensions'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 // Matches values in recent template from React Native 0.59 / 0.60
 // https://github.com/facebook/react-native/blob/0.59-stable/template/android/build.gradle#L5-L9


### PR DESCRIPTION
'kotlin-android-extensions' got deprecated for Gradle 7.0.0 and above, instead we need to use 'kotlin-parcelize'